### PR TITLE
Fixed Uploading Assets To GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ repo-*/
 /go-release
 /go-release.exe
 /info.go
+go-release-*/

--- a/build/build.go
+++ b/build/build.go
@@ -128,16 +128,20 @@ func Run(ca []string) error {
 
 	gh := github.NewClient(&http.Client{Timeout: time.Second * 5}, org, repo, token)
 
-	var err2 error
+	release, err2 := gh.GetReleaseIdByTag(version)
+	if err2 != nil {
+		return err2
+	}
+	var err3 error
 	for _, artifact := range artifacts {
-		if e := gh.UploadAsset(artifact, version); e != nil {
-			err2 = e
+		if _, e := gh.UploadAsset(artifact, release); e != nil {
+			err3 = e
 			break
 		}
 	}
 
-	if err2 != nil {
-		return err2
+	if err3 != nil {
+		return err3
 	}
 
 	return nil

--- a/pkg/github/message.go
+++ b/pkg/github/message.go
@@ -7,15 +7,19 @@ var stdout = struct {
 }
 
 var stderr = struct {
-	CouldNotBuildRequest string
-	CouldNotReadFile     string
-	CouldNotRequest      string
-	ReturnStatusCode     string
-	VersionArgEmpty      string
+	CouldNotBuildRequest     string
+	CouldNotDecodeJson       string
+	CouldNotReadFile         string
+	CouldNotReadResponseBody string
+	CouldNotRequest          string
+	ReturnStatusCode         string
+	VersionArgEmpty          string
 }{
-	CouldNotBuildRequest: "could not build a request: %s",
-	CouldNotReadFile:     "could not read %s: %s",
-	CouldNotRequest:      "problem with request to %s: %s",
-	ReturnStatusCode:     "unexpected return status code %d",
-	VersionArgEmpty:      "version argument cannot be an empty string",
+	CouldNotBuildRequest:     "could not build a request: %s",
+	CouldNotDecodeJson:       "could not decode JSON: %s",
+	CouldNotReadFile:         "could not read %s: %s",
+	CouldNotReadResponseBody: "could not read response body: %s",
+	CouldNotRequest:          "problem with request to %s: %s",
+	ReturnStatusCode:         "unexpected return status code %d",
+	VersionArgEmpty:          "version argument cannot be an empty string",
 }

--- a/pkg/github/model.go
+++ b/pkg/github/model.go
@@ -1,0 +1,83 @@
+package github
+
+import "time"
+
+type Author struct {
+	Login             string `json:"login"`
+	Id                int    `json:"id"`
+	NodeId            string `json:"node_id"`
+	AvatarUrl         string `json:"avatar_url"`
+	GravatarId        string `json:"gravatar_id"`
+	Url               string `json:"url"`
+	HtmlUrl           string `json:"html_url"`
+	FollowersUrl      string `json:"followers_url"`
+	FollowingUrl      string `json:"following_url"`
+	GistsUrl          string `json:"gists_url"`
+	StarredUrl        string `json:"starred_url"`
+	SubscriptionsUrl  string `json:"subscriptions_url"`
+	OrganizationsUrl  string `json:"organizations_url"`
+	ReposUrl          string `json:"repos_url"`
+	EventsUrl         string `json:"events_url"`
+	ReceivedEventsUrl string `json:"received_events_url"`
+	Type              string `json:"type"`
+	SiteAdmin         bool   `json:"site_admin"`
+}
+
+type Uploader struct {
+	Login             string `json:"login"`
+	Id                int    `json:"id"`
+	NodeId            string `json:"node_id"`
+	AvatarUrl         string `json:"avatar_url"`
+	GravatarId        string `json:"gravatar_id"`
+	Url               string `json:"url"`
+	HtmlUrl           string `json:"html_url"`
+	FollowersUrl      string `json:"followers_url"`
+	FollowingUrl      string `json:"following_url"`
+	GistsUrl          string `json:"gists_url"`
+	StarredUrl        string `json:"starred_url"`
+	SubscriptionsUrl  string `json:"subscriptions_url"`
+	OrganizationsUrl  string `json:"organizations_url"`
+	ReposUrl          string `json:"repos_url"`
+	EventsUrl         string `json:"events_url"`
+	ReceivedEventsUrl string `json:"received_events_url"`
+	Type              string `json:"type"`
+	SiteAdmin         bool   `json:"site_admin"`
+}
+
+type Asset struct {
+	Url                string    `json:"url"`
+	BrowserDownloadUrl string    `json:"browser_download_url"`
+	Id                 int       `json:"id"`
+	NodeId             string    `json:"node_id"`
+	Name               string    `json:"name"`
+	Label              string    `json:"label"`
+	State              string    `json:"state"`
+	ContentType        string    `json:"content_type"`
+	Size               int       `json:"size"`
+	DownloadCount      int       `json:"download_count"`
+	CreatedAt          time.Time `json:"created_at"`
+	UpdatedAt          time.Time `json:"updated_at"`
+	Uploader           Uploader  `json:"uploader"`
+}
+
+type Release struct {
+	Url             string    `json:"url"`
+	HtmlUrl         string    `json:"html_url"`
+	AssetsUrl       string    `json:"assets_url"`
+	UploadUrl       string    `json:"upload_url"`
+	TarballUrl      string    `json:"tarball_url"`
+	ZipballUrl      string    `json:"zipball_url"`
+	DiscussionUrl   string    `json:"discussion_url"`
+	Id              int       `json:"id"`
+	NodeId          string    `json:"node_id"`
+	TagName         string    `json:"tag_name"`
+	TargetCommitish string    `json:"target_commitish"`
+	Name            string    `json:"name"`
+	Body            string    `json:"body"`
+	Draft           bool      `json:"draft"`
+	Prerelease      bool      `json:"prerelease"`
+	CreatedAt       time.Time `json:"created_at"`
+	PublishedAt     time.Time `json:"published_at"`
+	Author          Author    `json:"author"`
+	Assets          []Asset   `json:"assets"`
+}


### PR DESCRIPTION
Fix errors with uploading asset through GitHub API. Missing release ID required to upload assets. Wrongly used releast tag. You need to use the release tag to grab the unique ID of a release first. Then use the ID to upload the asset.