### PR TITLE
Chore To Fixed Broken Release Pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,6 +215,7 @@ workflows:
                   context: << pipeline.parameters.ctx_docker >>
             - run-test:
                   context: << pipeline.parameters.ctx_docker >>
+                  requires: [ co ]
             - vro/tag-and-release:
                   context: << pipeline.parameters.ctx_auto_release >>
                   requires: [ run-test ]


### PR DESCRIPTION
Require checkout step before running test when running the release tag workflow.