### PR TITLE
Fixed CI Auto Release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ parameters:
         description: Indicates with workflow should run.
         type: string
     variables_file:
-        default: variables.env
+        default: go_ver.txt
         type: string
 
 jobs:


### PR DESCRIPTION
Go version file named incorrectly causing auto releases to fail.